### PR TITLE
Add request history

### DIFF
--- a/app/actions/project.js
+++ b/app/actions/project.js
@@ -1,11 +1,11 @@
 import { List, Record, Map } from 'immutable';
 const nodePath = require('path');
 
-import randomId from '../utils/randomId';
 import { execute as doExecuteRequest } from '../pragma/RequestExecutor';
 import prepareRequest from '../pragma/prepareRequest';
 import { awaitingResponse, receiveResponse, receiveError } from './response';
 import { readProject } from '../utils/projectUtils';
+import randomId from '../utils/randomId';
 
 export const UPSERT_PROJECT = 'UPSERT_PROJECT';
 export const CLOSE_PROJECT = 'CLOSE_PROJECT';
@@ -16,7 +16,7 @@ export const EXECUTE_REQUEST = 'EXECUTE_REQUEST';
 export const LOG_REQUEST = 'LOG_REQUEST';
 
 export const Request = Record({
-  id: undefined,
+  id: randomId(),
   projectId: undefined,
   name: undefined,
   method: undefined,
@@ -83,12 +83,10 @@ export function closeProjectByPath(path) {
 }
 
 export function addRequest(request, projectId) {
-  const newRequest = request.set('id', randomId()).set('projectId', projectId);
-
   return {
     type: ADD_REQUEST,
     projectId: projectId,
-    request: newRequest
+    request: request
   }
 }
 

--- a/app/actions/project.js
+++ b/app/actions/project.js
@@ -134,7 +134,6 @@ export function executeRequest(method:string, url:string, headers:Object, body:?
         dispatch(receiveResponse(response));
     });
 
-    dispatch(logRequest(request));
     dispatch(awaitingResponse({cancel: cancelRequest}));
   }
 }

--- a/app/actions/project.js
+++ b/app/actions/project.js
@@ -111,21 +111,22 @@ export function logRequest(request) {
   }
 }
 
-export function executeRequest(method:string, url:string, headers:Object, body:?string) {
+export function executeRequest(request:Request) {
   return (dispatch, getState) => {
     const state = getState();
     const activeEnvironmentId = state.ui.get('activeEnvironment');
     const activeEnvironment = state.environments.find(e => e.get('id') === activeEnvironmentId);
 
-    let request;
+    let preparedRequest;
     try {
-      request = prepareRequest(method, url, headers, body, activeEnvironment);
+      preparedRequest = prepareRequest(request.method, request.url, request.headers.toJS(), request.body, activeEnvironment);
+      dispatch(logRequest(request));
     } catch (e) {
       dispatch(receiveError(e));
       return;
     }
 
-    const cancelRequest = doExecuteRequest(request, (error, response) => {
+    const cancelRequest = doExecuteRequest(preparedRequest, (error, response) => {
       if (error)
         dispatch(receiveError(error));
       else

--- a/app/actions/project.js
+++ b/app/actions/project.js
@@ -13,6 +13,7 @@ export const ADD_REQUEST = 'ADD_REQUEST';
 export const UPDATE_REQUEST = 'UPDATE_REQUEST';
 export const DELETE_REQUEST = 'DELETE_REQUEST';
 export const EXECUTE_REQUEST = 'EXECUTE_REQUEST';
+export const LOG_REQUEST = 'LOG_REQUEST';
 
 export const Request = Record({
   id: undefined,
@@ -105,6 +106,13 @@ export function deleteRequest(request) {
   }
 }
 
+export function logRequest(request) {
+  return {
+    type: LOG_REQUEST,
+    request: request
+  }
+}
+
 export function executeRequest(method:string, url:string, headers:Object, body:?string) {
   return (dispatch, getState) => {
     const state = getState();
@@ -126,7 +134,7 @@ export function executeRequest(method:string, url:string, headers:Object, body:?
         dispatch(receiveResponse(response));
     });
 
+    dispatch(logRequest(request));
     dispatch(awaitingResponse({cancel: cancelRequest}));
   }
 }
-

--- a/app/actions/response.js
+++ b/app/actions/response.js
@@ -11,6 +11,9 @@ export function receiveResponse(response) {
 }
 
 export function receiveError(error) {
+
+  console.error(error);
+
   return {
     type: RECEIVE_ERROR,
     error: error

--- a/app/actions/response.js
+++ b/app/actions/response.js
@@ -11,9 +11,6 @@ export function receiveResponse(response) {
 }
 
 export function receiveError(error) {
-
-  console.error(error);
-
   return {
     type: RECEIVE_ERROR,
     error: error

--- a/app/actions/ui.js
+++ b/app/actions/ui.js
@@ -7,7 +7,10 @@ export const PUSH_PATH = 'PUSH_PATH';
 
 export function selectRequest(request) {
   return dispatch => {
-    dispatch(pushPath(`/projects/${request.projectId}/requests/${request.id}`));
+    if (request.projectId)
+      dispatch(pushPath(`/projects/${request.projectId}/requests/${request.id}`));
+    else
+      dispatch(pushPath(`/requests/${request.id}`));
 
     dispatch({
       type: SELECT_REQUEST,

--- a/app/components/RequestEditor.js
+++ b/app/components/RequestEditor.js
@@ -110,9 +110,9 @@ class RequestForm extends Component {
                     options={codeMirrorOptions(request)}
                     onChange={this.onBodyChange.bind(this)}/>
 
-        <input type="submit" value="Save"/>
+        {request.projectId && <input type="submit" value="Save"/>}
 
-        {request.id ? <button className="delete" onClick={this.props.onDelete}>Delete</button> : null}
+        {request.projectId && request.id && <button className="delete" onClick={this.props.onDelete}>Delete</button>}
       </form>
     )
   }

--- a/app/components/RequestsList.js
+++ b/app/components/RequestsList.js
@@ -79,7 +79,7 @@ class HistoryListItem extends Component {
           <span className="name">History</span>
         </div>
         {
-          history.map((request, index) =>
+          history.sort((a, b) => a.id < b.id).map((request, index) =>
             <RequestListItem key={index}
                              request={request}
                              selected={ request === selectedRequest }

--- a/app/components/RequestsList.js
+++ b/app/components/RequestsList.js
@@ -69,6 +69,28 @@ class ProjectListItem extends Component {
   }
 }
 
+class HistoryListItem extends Component {
+
+  render() {
+    const { history, selectedRequest } = this.props;
+    return (
+      <div className="project">
+        <div className="project-details">
+          <span className="name">History</span>
+        </div>
+        {
+          history.map((request, index) =>
+            <RequestListItem key={index}
+                             request={request}
+                             selected={ request === selectedRequest }
+                             onSelected={this.props.onRequestSelected}/>
+          )
+        }
+      </div>
+    );
+  }
+}
+
 class RequestsList extends Component {
   static propTypes = {
     requests: PropTypes.array
@@ -90,7 +112,7 @@ class RequestsList extends Component {
   }
 
   render() {
-    const { dispatch, projects, selectedRequest } = this.props;
+    const { dispatch, projects, history, selectedRequest } = this.props;
     if (projects.count() == 0)
       return null;
 
@@ -103,6 +125,9 @@ class RequestsList extends Component {
                            onNewRequest={this.onNewRequest.bind(this)}
                            onProjectClose={this.onProjectClose.bind(this)}/>
         )}
+        <HistoryListItem history={history}
+                         selectedRequest={selectedRequest}
+                         onRequestSelected={this.onRequestSelected.bind(this)}/>
       </div>
     );
   }
@@ -111,6 +136,7 @@ class RequestsList extends Component {
 function select(state) {
   return {
     projects: state.projects,
+    history: state.history,
     selectedRequest: state.ui.get('selectedRequest')
   }
 }

--- a/app/containers/EditRequestPage.js
+++ b/app/containers/EditRequestPage.js
@@ -13,8 +13,7 @@ class EditRequestPage extends Component {
   }
 
   onExecuteRequest(request) {
-    this.props.executeRequest(request.method, request.url, request.headers.toJS(), request.body);
-    this.props.logRequest(request);
+    this.props.executeRequest(request);
   }
 
   onDeleteRequest(request) {

--- a/app/containers/EditRequestPage.js
+++ b/app/containers/EditRequestPage.js
@@ -14,6 +14,7 @@ class EditRequestPage extends Component {
 
   onExecuteRequest(request) {
     this.props.executeRequest(request.method, request.url, request.headers.toJS(), request.body);
+    this.props.logRequest(request);
   }
 
   onDeleteRequest(request) {

--- a/app/containers/EditRequestPage.js
+++ b/app/containers/EditRequestPage.js
@@ -42,9 +42,22 @@ class EditRequestPage extends Component {
   }
 }
 
+function requestFromProjects(state, projectId, requestId) {
+  const project = state.projects.filter(p => p.id == projectId).get(0);
+  return project && project.requests.filter(r => r.id == requestId).get(0);
+}
+
+function requestFromHistory(state, requestId) {
+  return state.history.filter(r => r.id == requestId).get(0);
+}
+
 function mapStateToProps(state, ownProps) {
-  const project = state.projects.filter(p => p.id == ownProps.params.projectId).get(0);
-  const request = project && project.requests.filter(r => r.id == ownProps.params.id).get(0);
+  let request;
+
+  if (ownProps.params.projectId)
+    request = requestFromProjects(state, ownProps.params.projectId, ownProps.params.id);
+  else
+    request = requestFromHistory(state, ownProps.params.id);
 
   return {
     request: request,

--- a/app/containers/HomePage.js
+++ b/app/containers/HomePage.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router';
 import { connect } from 'react-redux';
-import RequestsList from '../components/RequestsList';
-import RequestEditor from '../components/RequestEditor';
 
 import Modal from '../components/Modal';
 import ProjectCreator from '../components/ProjectCreator';

--- a/app/containers/NewRequestPage.js
+++ b/app/containers/NewRequestPage.js
@@ -13,7 +13,12 @@ class NewRequestPage extends Component {
   }
 
   componentDidMount() {
-    this.setState({request: new Request({method: 'GET'})});
+    const newRequest = new Request({
+      method: 'GET',
+      projectId: this.props.params.projectId
+    });
+
+    this.setState({request: newRequest});
   }
 
   addRequest(request) {

--- a/app/containers/NewRequestPage.js
+++ b/app/containers/NewRequestPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import RequestEditor from '../components/RequestEditor';
 import ResponseViewer from '../components/ResponseViewer';
-import { Request, addRequest, executeRequest } from '../actions/project';
+import { Request, addRequest, executeRequest, logRequest } from '../actions/project';
 import { cancel } from '../actions/response';
 import { selectRequest } from '../actions/ui';
 
@@ -26,6 +26,7 @@ class NewRequestPage extends Component {
   onRequestExecute(request) {
     this.setState({request: request});
     this.props.dispatch(executeRequest(request.method, request.url, request.headers.toJS(), request.body));
+    this.props.dispatch(logRequest(request));
   }
 
   render() {

--- a/app/containers/NewRequestPage.js
+++ b/app/containers/NewRequestPage.js
@@ -30,8 +30,7 @@ class NewRequestPage extends Component {
 
   onRequestExecute(request) {
     this.setState({request: request});
-    this.props.dispatch(executeRequest(request.method, request.url, request.headers.toJS(), request.body));
-    this.props.dispatch(logRequest(request));
+    this.props.dispatch(executeRequest(request));
   }
 
   render() {

--- a/app/reducers/history.js
+++ b/app/reducers/history.js
@@ -1,0 +1,18 @@
+import { Request, LOG_REQUEST } from '../actions/project';
+import Immutable, { List, Record, Map } from 'immutable';
+
+export default function history(state = new List(), action) {
+
+  switch (action.type) {
+    case LOG_REQUEST:
+      debugger;
+
+      const loggedRequest = new Request(Immutable.fromJS(action.request))
+        .set('name', action.request.url)
+        .set('id', state.size);
+
+      return state.push(loggedRequest);
+    default:
+      return state;
+  }
+}

--- a/app/reducers/history.js
+++ b/app/reducers/history.js
@@ -5,11 +5,10 @@ export default function history(state = new List(), action) {
 
   switch (action.type) {
     case LOG_REQUEST:
-      debugger;
-
-      const loggedRequest = new Request(Immutable.fromJS(action.request))
-        .set('name', action.request.url)
-        .set('id', state.size);
+      const loggedRequest = new Request(action.request)
+        .remove('projectId')
+        .set('id', state.size)
+        .set('name', action.request.url);
 
       return state.push(loggedRequest);
     default:

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -4,12 +4,14 @@ import response from './response';
 import projects from './projects';
 import environments from './environments';
 import ui from './ui';
+import history from './history'
 
 const rootReducer = combineReducers({
   projects,
   response,
   ui,
   environments,
+  history,
   routing: routeReducer
 });
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -12,5 +12,6 @@ export default (
     <Route path="/projects/:projectId/requests/new" component={NewRequestPage}/>
     <Route path="/projects/:projectId/requests/:id" component={EditRequestPage}/>
     <Route path="/project/new" component={NewProjectPage}/>
+    <Route path="/requests/:id" component={EditRequestPage}/>
   </Route>
 );


### PR DESCRIPTION
Implementation is not fancy but gets the job done for now. Will probably make sense at some point to have a proper way to distinguish between "historical" requests vs requests that are an active part of a project
